### PR TITLE
Do not raise error when disabling and not yet enabled

### DIFF
--- a/lua/stcursorword/init.lua
+++ b/lua/stcursorword/init.lua
@@ -188,7 +188,7 @@ end
 
 local disable = function()
 	matchdelete()
-	api.nvim_del_augroup_by_name(PLUG_NAME)
+	pcall(api.nvim_del_augroup_by_name, PLUG_NAME)
 	enabled = false
 end
 


### PR DESCRIPTION
`api.nvim_del_augroup_by_name` raises an error when called with a group name that does not exist.
Since I've supercharged my `<esc>` to also call `<cmd>Cursorword disable<cr>`, I was interrupted a lot by errors.
This PR fixes that.

Hope you find this useful ✌🏻 